### PR TITLE
docs(rami-levy): Add local-only mode with clear production error message

### DIFF
--- a/backend/src/services/cooking/ramiLevyService.ts
+++ b/backend/src/services/cooking/ramiLevyService.ts
@@ -10,6 +10,18 @@
  * IMPORTANT: This is an unofficial integration. Users must provide their own
  * authentication tokens extracted from their browser session.
  * 
+ * ⚠️ CLOUDFLARE LIMITATION:
+ * This integration only works when running the backend LOCALLY (npm run dev).
+ * It does NOT work from Railway/production servers because:
+ * - Cloudflare's cf_clearance cookie is bound to the browser's IP address
+ * - When the server (Railway) makes requests, it has a different IP
+ * - Cloudflare rejects the request with a 403 error
+ * 
+ * For production use, consider:
+ * - Running as a local MCP server on the user's machine
+ * - Using a browser extension that runs in the Rami Levy context
+ * - Finding an alternative API that doesn't use Cloudflare protection
+ * 
  * @module services/cooking/ramiLevyService
  */
 
@@ -621,6 +633,25 @@ class RamiLevyService {
    */
   async initialize(userId: string): Promise<TokenStatus> {
     try {
+      // Check if we're in production and local-only mode is enabled
+      const isProduction = process.env.NODE_ENV === 'production';
+      const localOnlyMode = configService.get('ramiLevy.localOnlyMode', true);
+      
+      if (isProduction && localOnlyMode) {
+        logger.warn('Rami Levy is in local-only mode - not available in production');
+        return {
+          isValid: false,
+          userId,
+          errorMessage: 'Rami Levy integration is only available when running locally. ' +
+            'Due to Cloudflare protection, the API cannot be accessed from cloud servers (Railway). ' +
+            'Run the backend locally (npm run dev) to use this feature.',
+          refreshInstructions: 'To use Rami Levy:\n' +
+            '1. Run the backend locally: cd backend && npm run dev\n' +
+            '2. The local server shares your browser\'s IP, bypassing Cloudflare restrictions.\n' +
+            '3. Cloud deployment (Railway) cannot access this API due to IP binding.'
+        };
+      }
+
       const tokens = await this.getStoredTokens(userId);
 
       if (!tokens) {

--- a/backend/src/services/core/configService.ts
+++ b/backend/src/services/core/configService.ts
@@ -207,6 +207,7 @@ const DEFAULT_CONFIG = {
   'ramiLevy.circuitBreaker.threshold': 5,
   'ramiLevy.circuitBreaker.resetMs': 60000,
   'ramiLevy.skipCookiesForEcomToken': true, // Skip cookies when ecomToken is valid (avoids Cloudflare IP binding)
+  'ramiLevy.localOnlyMode': true, // When true, shows clear error in production instead of confusing Cloudflare errors
   
   // ==========================================================================
   // DELIVERY SERVICE


### PR DESCRIPTION
Rami Levy integration only works locally due to Cloudflare IP binding. Instead of confusing 403 errors in production, we now:

- Add comprehensive documentation explaining the limitation
- Add ramiLevy.localOnlyMode config option (default: true)
- Return clear error message in production explaining:
  - Why it doesn't work (Cloudflare IP binding)
  - How to use it (run locally with npm run dev)
  - Alternative solutions (local MCP, browser extension)

This sets proper expectations and avoids user confusion.