### PR TITLE
fix(ci): harden daily-code-review YAML against indentation breakage

### DIFF
--- a/.github/workflows/daily-code-review.yml
+++ b/.github/workflows/daily-code-review.yml
@@ -101,24 +101,26 @@ jobs:
                 } catch (_) { /* file may not exist */ }
               }
 
-              const prompt = `You are a strict principal tech lead reviewing a codebase.
-
-          Focus Area: ${focusArea}
-          Recently Changed Files:
-          ${changedFiles}
-
-          Key Files Context:
-          ${context}
-
-          Provide a concise daily review focusing on:
-          1. Any critical issues that need immediate attention
-          2. Code quality concerns
-          3. Security vulnerabilities
-          4. Performance bottlenecks
-          5. Technical debt items
-
-          Format as markdown suitable for a GitHub issue.
-          Keep the review actionable and under 2000 words.`;
+              const prompt = [
+                'You are a strict principal tech lead reviewing a codebase.',
+                '',
+                `Focus Area: ${focusArea}`,
+                'Recently Changed Files:',
+                changedFiles,
+                '',
+                'Key Files Context:',
+                context,
+                '',
+                'Provide a concise daily review focusing on:',
+                '1. Any critical issues that need immediate attention',
+                '2. Code quality concerns',
+                '3. Security vulnerabilities',
+                '4. Performance bottlenecks',
+                '5. Technical debt items',
+                '',
+                'Format as markdown suitable for a GitHub issue.',
+                'Keep the review actionable and under 2000 words.'
+              ].join('\n');
 
               const response = await client.messages.create({
                 model: 'claude-sonnet-4-20250514',


### PR DESCRIPTION
## Summary
- Replace fragile JavaScript template literal with `array.join('
')` pattern in `daily-code-review.yml`

The template literal had content lines at the YAML block scalar's base indentation level (10 spaces). While this happens to parse correctly today, any future edit that reduces indentation would break YAML parsing — the same issue that caused the `apply-review-fixes.yml` failure (fixed in PR #24).

This is a defensive fix for consistency with the pattern already used in `apply-review-fixes.yml`.

## Test plan
- [x] YAML validated with pyyaml — passes
- [x] Structural validation — all required fields present
- [ ] Verify daily-code-review workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)