### PR TITLE
feat(jobs): add Apply AI, Jobicy, StartupNationCentral, and freshness…

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -296,6 +296,11 @@ model SavedJob {
   // Company enrichment
   companyInfo Json?    // Crunchbase-like data
 
+  // Application package (AI-generated)
+  coverLetter     String?  @db.Text
+  emailTemplate   String?  @db.Text
+  applicationDocs Json?    // Additional uploaded resources metadata
+
   // Status
   status      String   @default("saved") // "saved", "applied", "interviewing", "rejected", "accepted"
   appliedAt   DateTime?

--- a/backend/src/controllers/jobController.ts
+++ b/backend/src/controllers/jobController.ts
@@ -8,6 +8,7 @@ import israelTechScraperService from '../services/jobs/israelTechScraperService'
 import companyEnrichmentService from '../services/jobs/companyEnrichmentService';
 import processControlService from '../services/core/processControlService';
 import { databaseService } from '../services/core/databaseService';
+import jobApplicationService from '../services/jobs/jobApplicationService';
 import logger from '../utils/logger';
 import fs from 'fs';
 import path from 'path';
@@ -805,6 +806,120 @@ export const getTrendingCompanies = async (req: Request, res: Response) => {
     });
   } catch (error: any) {
     logger.fail('Get trending companies error', { error: error.message });
+    res.status(500).json({ error: error.message });
+  }
+};
+
+// =============================================================================
+// APPLY AI ENDPOINTS
+// =============================================================================
+
+export const generateJobApplication = async (req: Request, res: Response) => {
+  try {
+    const { jobData, tone, additionalContext } = req.body;
+
+    if (!jobData) {
+      return res.status(400).json({ error: 'jobData is required' });
+    }
+
+    const cvDataPath = path.join(__dirname, '../../data/cv-data.json');
+    if (!fs.existsSync(cvDataPath)) {
+      return res.status(400).json({ error: 'Please upload your CV first' });
+    }
+
+    const fileContent = JSON.parse(fs.readFileSync(cvDataPath, 'utf-8'));
+    const cvData = fileContent.cvData || fileContent;
+
+    const applicationPackage = await jobApplicationService.generateApplicationPackage(
+      jobData,
+      cvData,
+      { tone, additionalContext }
+    );
+
+    res.json({ success: true, ...applicationPackage });
+  } catch (error: any) {
+    logger.fail('Generate job application error', { error: error.message });
+    res.status(500).json({ error: error.message });
+  }
+};
+
+export const trackJobApplication = async (req: Request, res: Response) => {
+  try {
+    const { jobId, jobData, status, notes, appliedAt } = req.body;
+
+    if (!jobId) {
+      return res.status(400).json({ error: 'jobId is required' });
+    }
+
+    const user = await databaseService.getDefaultUser();
+    if (!user) {
+      return res.status(400).json({ error: 'No user found' });
+    }
+
+    const prisma = databaseService.getClient();
+    if (!prisma) {
+      return res.status(503).json({ error: 'Database not available' });
+    }
+
+    const jobSource = jobData?.source || 'unknown';
+
+    const savedJob = await prisma.savedJob.upsert({
+      where: {
+        userId_jobId_source: { userId: user.id, jobId, source: jobSource }
+      },
+      update: {
+        status: status || 'applied',
+        notes: notes || undefined,
+        appliedAt: appliedAt ? new Date(appliedAt) : (status === 'applied' ? new Date() : undefined),
+        updatedAt: new Date()
+      },
+      create: {
+        userId: user.id,
+        jobId,
+        title: jobData?.title || 'Unknown',
+        company: jobData?.company || 'Unknown',
+        location: jobData?.location,
+        salary: jobData?.salary,
+        description: jobData?.description,
+        url: jobData?.applyUrl,
+        source: jobSource,
+        matchScore: jobData?.matchScore,
+        status: status || 'applied',
+        notes,
+        appliedAt: status === 'applied' ? new Date() : undefined
+      }
+    });
+
+    res.json({ success: true, savedJob });
+  } catch (error: any) {
+    logger.fail('Track job application error', { error: error.message });
+    res.status(500).json({ error: error.message });
+  }
+};
+
+export const getJobApplications = async (req: Request, res: Response) => {
+  try {
+    const user = await databaseService.getDefaultUser();
+    if (!user) {
+      return res.status(400).json({ error: 'No user found' });
+    }
+
+    const prisma = databaseService.getClient();
+    if (!prisma) {
+      return res.status(503).json({ error: 'Database not available' });
+    }
+
+    const applications = await prisma.savedJob.findMany({
+      where: {
+        userId: user.id,
+        status: { not: 'saved' }
+      },
+      orderBy: { appliedAt: 'desc' }
+    });
+
+    res.json({ success: true, applications });
+  } catch (error: any) {
+    logger.fail('Get job applications error', { error: error.message });
     res.status(500).json({ error: error.message });
   }
 };

--- a/backend/src/routes/jobs.ts
+++ b/backend/src/routes/jobs.ts
@@ -46,4 +46,9 @@ router.post('/interview/system-design/evaluate', jobController.evaluateSystemDes
 router.get('/interview/system-design/questions', jobController.getSystemDesignQuestions);
 router.post('/interview/system-design/generate', jobController.generateSystemDesignDiagram);
 
+// Apply AI
+router.post('/apply-ai', jobController.generateJobApplication);
+router.post('/application/track', jobController.trackJobApplication);
+router.get('/applications', jobController.getJobApplications);
+
 export default router;

--- a/backend/src/services/jobs/additionalJobAPIs.ts
+++ b/backend/src/services/jobs/additionalJobAPIs.ts
@@ -229,6 +229,71 @@ class AdditionalJobAPIs {
   }
 
   /**
+   * Fetch jobs from Jobicy (FREE, no auth required)
+   * Remote tech jobs with tag-based search
+   * API: https://jobicy.com/api/v2/remote-jobs
+   */
+  async fetchJobicy(query: string): Promise<JobListing[]> {
+    try {
+      console.log('🔍 Fetching jobs from Jobicy...');
+
+      // Jobicy uses tag-based search — use first meaningful keyword
+      const keyword = query.split(' ').find(word => word.length > 3) || query;
+
+      const response = await axios.get('https://jobicy.com/api/v2/remote-jobs', {
+        params: {
+          count: 50,
+          tag: keyword
+        },
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+        },
+        timeout: JOB_API_TIMEOUT(),
+        validateStatus: (status) => status < 500
+      });
+
+      if (response.status === 401 || response.status === 403) {
+        console.log('⚠️ Jobicy API blocked - skipping');
+        return [];
+      }
+
+      const jobs: any[] = response.data?.jobs || [];
+
+      const queryLower = query.toLowerCase();
+      const formatted = jobs
+        .filter((job: any) => {
+          const text = `${job.jobTitle} ${job.jobDescription}`.toLowerCase();
+          return text.includes(queryLower) ||
+                 queryLower.split(' ').some(word => word.length > 3 && text.includes(word));
+        })
+        .slice(0, configService.get('limits.jobs.apis.himalayas.maxResults', 20) as number)
+        .map((job: any) => ({
+          id: `jobicy-${job.id}`,
+          source: 'Jobicy',
+          title: job.jobTitle,
+          company: job.companyName || 'Unknown',
+          location: job.jobGeo || 'Remote',
+          remote: true,
+          description: job.jobDescription || '',
+          applyUrl: job.url || `https://jobicy.com/jobs/${job.id}`,
+          salary: job.annualSalaryMin && job.annualSalaryMax
+            ? `$${Number(job.annualSalaryMin).toLocaleString()} - $${Number(job.annualSalaryMax).toLocaleString()}`
+            : undefined,
+          postedAt: job.pubDate || new Date().toISOString(),
+          tags: job.jobIndustry ? [job.jobIndustry] : [],
+          companySize: this.detectCompanySize(undefined),
+          experienceLevel: this.detectExperienceLevel(job.jobTitle, job.jobDescription)
+        }));
+
+      console.log(`✅ Found ${formatted.length} jobs from Jobicy`);
+      return formatted;
+    } catch (error: any) {
+      console.error('❌ Error fetching from Jobicy:', error.message);
+      return [];
+    }
+  }
+
+  /**
    * Detect company size from text
    */
   private detectCompanySize(size?: string): 'startup' | 'midsize' | 'enterprise' | undefined {

--- a/backend/src/services/jobs/jobApplicationService.ts
+++ b/backend/src/services/jobs/jobApplicationService.ts
@@ -1,0 +1,140 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+interface JobListing {
+  id: string;
+  title: string;
+  company: string;
+  description: string;
+  location?: string;
+  salary?: string;
+  [key: string]: any;
+}
+
+interface CVData {
+  name?: string;
+  skills?: string[];
+  desiredRoles?: string[];
+  yearsOfExperience?: number;
+  experience?: Array<{ role?: string; company?: string; description?: string; years?: number }>;
+  seniorityLevel?: string;
+  currentRole?: string;
+  education?: Array<{ degree?: string; institution?: string }>;
+  [key: string]: any;
+}
+
+export interface ApplicationPackage {
+  coverLetter: string;
+  emailTemplate: string;
+  applicationTips: string[];
+  skillGapAdvice: string;
+  keyStrengths: string[];
+}
+
+class JobApplicationService {
+  private client: Anthropic | null = null;
+
+  private initializeClient() {
+    if (this.client) return;
+
+    const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
+    if (!apiKey) {
+      throw new Error('ANTHROPIC_API_KEY is not set');
+    }
+
+    this.client = new Anthropic({ apiKey });
+  }
+
+  async generateApplicationPackage(
+    job: JobListing,
+    cvData: CVData,
+    options?: {
+      tone?: 'professional' | 'enthusiastic' | 'concise';
+      additionalContext?: string;
+    }
+  ): Promise<ApplicationPackage> {
+    this.initializeClient();
+
+    if (!this.client) {
+      throw new Error('Failed to initialize Anthropic client');
+    }
+
+    const tone = options?.tone || 'professional';
+    const additionalContext = options?.additionalContext || '';
+
+    const actualCVData = (cvData as any).cvData || cvData;
+    const skills = actualCVData.skills || [];
+    const experience = actualCVData.experience || [];
+    const name = actualCVData.name || 'the candidate';
+    const yearsOfExperience = actualCVData.yearsOfExperience || 0;
+    const currentRole = actualCVData.currentRole || actualCVData.seniorityLevel || '';
+
+    const experienceSummary = experience
+      .slice(0, 5)
+      .map((exp: any) => `${exp.role || exp.title || 'Role'} at ${exp.company || 'Company'}: ${exp.description?.substring(0, 150) || ''}`)
+      .join('\n');
+
+    const prompt = `You are an expert career coach and professional writer. Generate a complete job application package.
+
+JOB POSTING:
+Title: ${job.title}
+Company: ${job.company}
+Location: ${job.location || 'Not specified'}
+Salary: ${job.salary || 'Not specified'}
+Description: ${job.description?.substring(0, 2000) || 'No description available'}
+
+CANDIDATE PROFILE:
+Name: ${name}
+Current Role: ${currentRole}
+Years of Experience: ${yearsOfExperience}
+Key Skills: ${skills.slice(0, 20).join(', ')}
+Recent Experience:
+${experienceSummary}
+${additionalContext ? `\nAdditional Context from Candidate:\n${additionalContext}` : ''}
+
+TONE: ${tone}
+
+Generate a JSON response with EXACTLY this structure (no markdown, pure JSON):
+{
+  "coverLetter": "A 3-4 paragraph tailored cover letter. First paragraph: strong opener connecting candidate to role. Second paragraph: most relevant experience with specific achievements. Third paragraph: why this company specifically. Fourth paragraph: call to action.",
+  "emailTemplate": "A concise 3-paragraph cold email version (max 150 words total). Subject line on first line prefixed with 'Subject: ', then two blank lines, then the email body.",
+  "applicationTips": ["tip1", "tip2", "tip3", "tip4", "tip5"],
+  "skillGapAdvice": "One paragraph on how to address any skill gaps identified and how to frame experience positively.",
+  "keyStrengths": ["strength1 with specific evidence from CV", "strength2", "strength3", "strength4", "strength5"]
+}
+
+Important: Return ONLY valid JSON. No preamble, no markdown code blocks.`;
+
+    const message = await this.client.messages.create({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 2048,
+      messages: [{ role: 'user', content: prompt }]
+    });
+
+    const rawText = message.content[0].type === 'text' ? message.content[0].text : '';
+
+    try {
+      // Strip any accidental markdown fences
+      const cleanedText = rawText.replace(/^```(?:json)?\n?/m, '').replace(/\n?```$/m, '').trim();
+      const parsed = JSON.parse(cleanedText);
+
+      return {
+        coverLetter: parsed.coverLetter || '',
+        emailTemplate: parsed.emailTemplate || '',
+        applicationTips: Array.isArray(parsed.applicationTips) ? parsed.applicationTips : [],
+        skillGapAdvice: parsed.skillGapAdvice || '',
+        keyStrengths: Array.isArray(parsed.keyStrengths) ? parsed.keyStrengths : []
+      };
+    } catch {
+      // If parsing fails, return structured error with raw text as cover letter
+      return {
+        coverLetter: rawText,
+        emailTemplate: '',
+        applicationTips: ['Unable to parse structured tips — see cover letter for full content.'],
+        skillGapAdvice: '',
+        keyStrengths: []
+      };
+    }
+  }
+}
+
+export default new JobApplicationService();

--- a/backend/src/services/jobs/jobSourceService.ts
+++ b/backend/src/services/jobs/jobSourceService.ts
@@ -4,6 +4,7 @@ import israeliJobsService from './israeliJobsService';
 import comeetCareersService from './comeetCareersService';
 import israeliTechCommunityService from './israeliTechCommunityService';
 import israelTechScraperService from './israelTechScraperService';
+import startupNationCentralService from './startupNationCentralService';
 import { googleSearchService } from '../core/googleSearchService';
 import { configService } from '../core/configService';
 
@@ -541,7 +542,7 @@ class JobSourceService {
           query: searchQuery,
           page: '1',
           num_pages: '1',
-          date_posted: 'month', // Last month instead of 'all' for fresher results
+          date_posted: 'week', // Last 7 days only — much more likely to be open
           remote_jobs_only: location ? 'false' : 'false', // Changed to false to get more results
           employment_types: 'FULLTIME,CONTRACTOR,PARTTIME'
         }
@@ -663,12 +664,10 @@ class JobSourceService {
       } else if (location?.toLowerCase().includes('germany')) {
         countryCode = 'de';
       } else if (location?.toLowerCase().includes('israel') || location?.toLowerCase().includes('tel aviv')) {
-        countryCode = 'il';
-      }
-      else{
-        console.log(`ℹ️ Adzuna does not support Country ${countryCode}. Skipping...`);
+        console.log('ℹ️ Adzuna does not support Israel. Skipping...');
         return [];
       }
+      // All other locations default to 'us'
 
       const response = await axios.get(
         `https://api.adzuna.com/v1/api/jobs/${countryCode}/search/1`,
@@ -1091,11 +1090,12 @@ ${[...new Set(jobs.map(j => j.location))].slice(0, configService.get('limits.job
     );
     
     // Additional APIs (may have mixed remote/office jobs)
-    apiList.push('The Muse', 'Findwork.dev', 'Himalayas');
+    apiList.push('The Muse', 'Findwork.dev', 'Himalayas', 'Jobicy');
     promises.push(
       additionalJobAPIs.fetchTheMuse(finalQuery, searchOptions.location).then(jobs => ({ source: 'The Muse', jobs })),
       additionalJobAPIs.fetchFindwork(finalQuery).then(jobs => ({ source: 'Findwork.dev', jobs })),
-      additionalJobAPIs.fetchHimalayas(finalQuery).then(jobs => ({ source: 'Himalayas', jobs }))
+      additionalJobAPIs.fetchHimalayas(finalQuery).then(jobs => ({ source: 'Himalayas', jobs })),
+      additionalJobAPIs.fetchJobicy(finalQuery).then(jobs => ({ source: 'Jobicy', jobs }))
     );
     
     // Add Israeli tech companies if location is Israel
@@ -1133,19 +1133,25 @@ ${[...new Set(jobs.map(j => j.location))].slice(0, configService.get('limits.job
       }
     }
     
+    // StartupNationCentral — Israeli startup ecosystem discovery (all searches)
+    apiList.push('StartupNationCentral');
+    promises.push(
+      startupNationCentralService.searchStartups(finalQuery).then(jobs => ({ source: 'StartupNationCentral', jobs }))
+    );
+
     // Notify about which APIs will be used
     if (socketIo) {
       const apiCount = apiList.length;
-      const modeText = searchOptions.remoteOnly === true ? ' (Remote Only)' : 
+      const modeText = searchOptions.remoteOnly === true ? ' (Remote Only)' :
                        searchOptions.remoteOnly === false ? ' (Office Only)' : '';
-      socketIo.emit('log', { 
-        message: `📡 Using ${apiCount} APIs${modeText}: ${apiList.join(' + ')}`, 
-        type: 'info' 
+      socketIo.emit('log', {
+        message: `📡 Using ${apiCount} APIs${modeText}: ${apiList.join(' + ')}`,
+        type: 'info'
       });
     }
-    
+
     // Execute all API calls
-    
+
     // Add premium APIs if configured
     if (process.env.RAPIDAPI_KEY) {
       promises.push(

--- a/backend/src/services/jobs/startupNationCentralService.ts
+++ b/backend/src/services/jobs/startupNationCentralService.ts
@@ -1,0 +1,146 @@
+import axios from 'axios';
+import { configService } from '../core/configService';
+
+const JOB_API_TIMEOUT = () => configService.get('jobs.api.timeoutMs', 15000);
+
+interface StartupInfo {
+  name: string;
+  website?: string;
+  description?: string;
+  industry?: string;
+  stage?: string;
+  employees?: string;
+  location?: string;
+}
+
+interface JobListing {
+  id: string;
+  source: string;
+  title: string;
+  company: string;
+  location: string;
+  remote: boolean;
+  description: string;
+  applyUrl: string;
+  salary?: string;
+  postedAt: string;
+  tags?: string[];
+  companySize?: 'startup' | 'midsize' | 'enterprise';
+  industry?: string[];
+  experienceLevel?: 'junior' | 'mid' | 'senior';
+  jobType?: 'fulltime' | 'contract' | 'freelance' | 'internship';
+}
+
+class StartupNationCentralService {
+  private readonly baseUrl = 'https://finder.startupnationcentral.org';
+
+  /**
+   * Search for Israeli startups on StartupNationCentral.
+   * Converts each startup into a JobListing pointing at its careers page.
+   * Degrades gracefully if the API is blocked (403/network error).
+   */
+  async searchStartups(
+    query: string,
+    options?: { industry?: string; stage?: string; limit?: number }
+  ): Promise<JobListing[]> {
+    try {
+      console.log(`🔍 Searching StartupNationCentral for: "${query}"`);
+
+      const limit = options?.limit ?? configService.get('limits.jobs.apis.himalayas.maxResults', 20) as number;
+
+      const requestBody: Record<string, unknown> = {
+        query,
+        from: 0,
+        size: limit
+      };
+
+      if (options?.industry) {
+        requestBody.filters = { industry: options.industry };
+      }
+      if (options?.stage) {
+        requestBody.filters = { ...(requestBody.filters as object || {}), stage: options.stage };
+      }
+
+      const response = await axios.post(
+        `${this.baseUrl}/api/startups/search`,
+        requestBody,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+            'Referer': 'https://finder.startupnationcentral.org/startups/search',
+            'Origin': 'https://finder.startupnationcentral.org'
+          },
+          timeout: JOB_API_TIMEOUT(),
+          validateStatus: (status) => status < 500
+        }
+      );
+
+      if (response.status === 401 || response.status === 403 || response.status === 404) {
+        console.log(`⚠️ StartupNationCentral API returned ${response.status} - skipping`);
+        return [];
+      }
+
+      const hits: any[] = response.data?.hits?.hits || response.data?.results || response.data?.data || [];
+
+      if (hits.length === 0) {
+        console.log('⚠️ StartupNationCentral returned no results');
+        return [];
+      }
+
+      const startups: StartupInfo[] = hits.map((hit: any) => {
+        const src = hit._source || hit;
+        return {
+          name: src.name || src.displayName || 'Unknown',
+          website: src.websiteUrl || src.website,
+          description: src.description || src.shortDescription || '',
+          industry: src.industries?.[0] || src.industry,
+          stage: src.stage || src.fundingStage,
+          employees: src.employeeCount || src.teamSize,
+          location: src.location || src.hq || 'Israel'
+        };
+      });
+
+      const listings = startups.map((startup): JobListing => {
+        const careersUrl = startup.website
+          ? `${startup.website.replace(/\/$/, '')}/careers`
+          : `https://finder.startupnationcentral.org/startups/search`;
+
+        return {
+          id: `snc-${startup.name.toLowerCase().replace(/\s+/g, '-')}`,
+          source: 'StartupNationCentral',
+          title: `Opportunities at ${startup.name}`,
+          company: startup.name,
+          location: startup.location || 'Israel',
+          remote: false,
+          description: [
+            startup.description,
+            startup.industry ? `Industry: ${startup.industry}` : '',
+            startup.stage ? `Stage: ${startup.stage}` : '',
+            startup.employees ? `Team size: ${startup.employees}` : ''
+          ].filter(Boolean).join('\n'),
+          applyUrl: careersUrl,
+          postedAt: new Date().toISOString(),
+          tags: [startup.industry].filter(Boolean) as string[],
+          companySize: 'startup',
+          industry: startup.industry ? [startup.industry] : []
+        };
+      });
+
+      console.log(`✅ Found ${listings.length} startups from StartupNationCentral`);
+      return listings;
+    } catch (error: any) {
+      if (error.response?.status === 403) {
+        console.log('⚠️ StartupNationCentral: access blocked (403) - skipping');
+      } else if (error.code === 'ECONNABORTED') {
+        console.log('⚠️ StartupNationCentral: request timeout - skipping');
+      } else {
+        console.error('❌ StartupNationCentral error:', error.message);
+      }
+      return [];
+    }
+  }
+}
+
+export default new StartupNationCentralService();

--- a/frontend/src/components/ApplyAIModal.tsx
+++ b/frontend/src/components/ApplyAIModal.tsx
@@ -1,0 +1,421 @@
+import React, { useState, useEffect } from 'react';
+import { X, Copy, Check, RefreshCw, Briefcase, FileText, Mail, Lightbulb, CheckSquare } from 'lucide-react';
+import { API_BASE_URL } from '../config';
+
+interface Job {
+  id: string;
+  source: string;
+  title: string;
+  company: string;
+  location: string;
+  remote: boolean;
+  description: string;
+  applyUrl: string;
+  salary?: string;
+  postedAt: string;
+  matchScore?: number;
+}
+
+interface ApplicationPackage {
+  coverLetter: string;
+  emailTemplate: string;
+  applicationTips: string[];
+  skillGapAdvice: string;
+  keyStrengths: string[];
+}
+
+interface ApplyAIModalProps {
+  job: Job;
+  onClose: () => void;
+  onMarkedApplied?: (jobId: string) => void;
+}
+
+type Tone = 'professional' | 'enthusiastic' | 'concise';
+type ActiveTab = 'cover-letter' | 'email' | 'tips';
+
+const ApplyAIModal: React.FC<ApplyAIModalProps> = ({ job, onClose, onMarkedApplied }) => {
+  const [tone, setTone] = useState<Tone>('professional');
+  const [additionalContext, setAdditionalContext] = useState('');
+  const [applicationPackage, setApplicationPackage] = useState<ApplicationPackage | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [activeTab, setActiveTab] = useState<ActiveTab>('cover-letter');
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+  const [editedCoverLetter, setEditedCoverLetter] = useState('');
+  const [editedEmail, setEditedEmail] = useState('');
+  const [isMarkingApplied, setIsMarkingApplied] = useState(false);
+  const [isApplied, setIsApplied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+      document.body.style.overflow = '';
+    };
+  }, [onClose]);
+
+  const generate = async () => {
+    setIsGenerating(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/jobs/apply-ai`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jobData: job, tone, additionalContext })
+      });
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.error || `Request failed (${response.status})`);
+      }
+
+      const data = await response.json();
+      setApplicationPackage(data);
+      setEditedCoverLetter(data.coverLetter);
+      setEditedEmail(data.emailTemplate);
+      setActiveTab('cover-letter');
+    } catch (err: any) {
+      setError(err.message || 'Failed to generate application package');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const copyToClipboard = async (text: string, field: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedField(field);
+      setTimeout(() => setCopiedField(null), 2000);
+    } catch {
+      // Fallback for older browsers
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      setCopiedField(field);
+      setTimeout(() => setCopiedField(null), 2000);
+    }
+  };
+
+  const markAsApplied = async () => {
+    setIsMarkingApplied(true);
+    try {
+      const response = await fetch(`${API_BASE_URL}/jobs/application/track`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jobId: job.id,
+          jobData: job,
+          status: 'applied',
+          appliedAt: new Date().toISOString()
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to track application');
+      }
+
+      setIsApplied(true);
+      onMarkedApplied?.(job.id);
+      setTimeout(() => onClose(), 1500);
+    } catch (err: any) {
+      setError(err.message || 'Failed to track application');
+    } finally {
+      setIsMarkingApplied(false);
+    }
+  };
+
+  const getMatchColor = (score?: number) => {
+    if (!score) return 'bg-gray-500/20 text-gray-300';
+    if (score >= 80) return 'bg-green-500/20 text-green-300';
+    if (score >= 60) return 'bg-yellow-500/20 text-yellow-300';
+    return 'bg-red-500/20 text-red-300';
+  };
+
+  const toneOptions: { value: Tone; label: string; description: string }[] = [
+    { value: 'professional', label: 'Professional', description: 'Formal and polished' },
+    { value: 'enthusiastic', label: 'Enthusiastic', description: 'Energetic and passionate' },
+    { value: 'concise', label: 'Concise', description: 'Brief and to the point' }
+  ];
+
+  const tabs: { id: ActiveTab; label: string; icon: React.ReactNode }[] = [
+    { id: 'cover-letter', label: 'Cover Letter', icon: <FileText className="w-4 h-4" /> },
+    { id: 'email', label: 'Email Template', icon: <Mail className="w-4 h-4" /> },
+    { id: 'tips', label: 'Tips & Insights', icon: <Lightbulb className="w-4 h-4" /> }
+  ];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-3xl max-h-[90vh] overflow-y-auto bg-slate-900 border border-white/20 rounded-2xl shadow-2xl"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="sticky top-0 z-10 bg-slate-900 border-b border-white/10 px-6 py-4 flex items-start justify-between">
+          <div className="flex-1 min-w-0 pr-4">
+            <div className="flex items-center gap-2 mb-1">
+              <Briefcase className="w-5 h-5 text-purple-400 flex-shrink-0" />
+              <h2 className="text-lg font-bold text-white truncate">{job.title}</h2>
+              {job.matchScore && (
+                <span className={`px-2 py-0.5 rounded-full text-xs font-semibold flex-shrink-0 ${getMatchColor(job.matchScore)}`}>
+                  {job.matchScore}% Match
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-slate-400">{job.company} · {job.location}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-white transition-colors flex-shrink-0"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-6 space-y-6">
+          {/* Controls */}
+          <div className="space-y-4">
+            {/* Tone selector */}
+            <div>
+              <label className="text-sm font-medium text-slate-300 mb-2 block">Tone</label>
+              <div className="flex gap-2">
+                {toneOptions.map(option => (
+                  <button
+                    key={option.value}
+                    onClick={() => setTone(option.value)}
+                    className={`flex-1 py-2 px-3 rounded-lg border text-sm font-medium transition-all ${
+                      tone === option.value
+                        ? 'border-purple-500 bg-purple-500/20 text-purple-300'
+                        : 'border-white/10 bg-white/5 text-slate-400 hover:border-white/20 hover:text-slate-300'
+                    }`}
+                  >
+                    <div>{option.label}</div>
+                    <div className="text-xs font-normal opacity-70">{option.description}</div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Additional context */}
+            <div>
+              <label className="text-sm font-medium text-slate-300 mb-2 block">
+                Additional Context <span className="text-slate-500 font-normal">(optional)</span>
+              </label>
+              <textarea
+                value={additionalContext}
+                onChange={e => setAdditionalContext(e.target.value)}
+                placeholder="e.g. I worked on a similar distributed system at my previous role, specifically handling 10k RPS..."
+                rows={3}
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-purple-500/50 resize-none"
+              />
+            </div>
+
+            {/* Generate button */}
+            <button
+              onClick={generate}
+              disabled={isGenerating}
+              className="w-full flex items-center justify-center gap-2 bg-purple-600 hover:bg-purple-700 disabled:opacity-60 disabled:cursor-not-allowed px-4 py-3 rounded-lg font-semibold transition-colors"
+            >
+              {isGenerating ? (
+                <>
+                  <RefreshCw className="w-4 h-4 animate-spin" />
+                  Generating application package...
+                </>
+              ) : applicationPackage ? (
+                <>
+                  <RefreshCw className="w-4 h-4" />
+                  Regenerate
+                </>
+              ) : (
+                <>
+                  <Briefcase className="w-4 h-4" />
+                  Generate Application Package
+                </>
+              )}
+            </button>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="bg-red-500/10 border border-red-500/30 rounded-lg px-4 py-3 text-red-300 text-sm">
+              {error}
+            </div>
+          )}
+
+          {/* Results */}
+          {applicationPackage && (
+            <div className="space-y-4">
+              {/* Tabs */}
+              <div className="flex gap-1 bg-white/5 rounded-lg p-1">
+                {tabs.map(tab => (
+                  <button
+                    key={tab.id}
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`flex-1 flex items-center justify-center gap-2 py-2 px-3 rounded-md text-sm font-medium transition-all ${
+                      activeTab === tab.id
+                        ? 'bg-white/10 text-white'
+                        : 'text-slate-400 hover:text-slate-300'
+                    }`}
+                  >
+                    {tab.icon}
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+
+              {/* Cover Letter Tab */}
+              {activeTab === 'cover-letter' && (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-slate-400">
+                      {editedCoverLetter.split(/\s+/).filter(Boolean).length} words
+                    </span>
+                    <button
+                      onClick={() => copyToClipboard(editedCoverLetter, 'cover-letter')}
+                      className="flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors"
+                    >
+                      {copiedField === 'cover-letter' ? (
+                        <><Check className="w-4 h-4 text-green-400" /> Copied!</>
+                      ) : (
+                        <><Copy className="w-4 h-4" /> Copy Cover Letter</>
+                      )}
+                    </button>
+                  </div>
+                  <textarea
+                    value={editedCoverLetter}
+                    onChange={e => setEditedCoverLetter(e.target.value)}
+                    rows={16}
+                    className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm text-slate-200 focus:outline-none focus:border-purple-500/50 resize-none font-sans leading-relaxed"
+                  />
+                </div>
+              )}
+
+              {/* Email Tab */}
+              {activeTab === 'email' && (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-slate-400">
+                      {editedEmail.split(/\s+/).filter(Boolean).length} words
+                    </span>
+                    <button
+                      onClick={() => copyToClipboard(editedEmail, 'email')}
+                      className="flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors"
+                    >
+                      {copiedField === 'email' ? (
+                        <><Check className="w-4 h-4 text-green-400" /> Copied!</>
+                      ) : (
+                        <><Copy className="w-4 h-4" /> Copy Email</>
+                      )}
+                    </button>
+                  </div>
+                  <textarea
+                    value={editedEmail}
+                    onChange={e => setEditedEmail(e.target.value)}
+                    rows={10}
+                    className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm text-slate-200 focus:outline-none focus:border-purple-500/50 resize-none font-sans leading-relaxed"
+                  />
+                </div>
+              )}
+
+              {/* Tips Tab */}
+              {activeTab === 'tips' && (
+                <div className="space-y-4">
+                  {/* Key Strengths */}
+                  {applicationPackage.keyStrengths.length > 0 && (
+                    <div className="bg-green-500/5 border border-green-500/20 rounded-lg p-4">
+                      <h4 className="text-sm font-semibold text-green-400 mb-3 flex items-center gap-2">
+                        <Check className="w-4 h-4" /> Key Strengths for This Role
+                      </h4>
+                      <ul className="space-y-2">
+                        {applicationPackage.keyStrengths.map((strength, idx) => (
+                          <li key={idx} className="text-sm text-slate-300 flex gap-2">
+                            <span className="text-green-500 flex-shrink-0">•</span>
+                            {strength}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  {/* Application Tips */}
+                  {applicationPackage.applicationTips.length > 0 && (
+                    <div className="bg-blue-500/5 border border-blue-500/20 rounded-lg p-4">
+                      <h4 className="text-sm font-semibold text-blue-400 mb-3 flex items-center gap-2">
+                        <Lightbulb className="w-4 h-4" /> Application Tips
+                      </h4>
+                      <ul className="space-y-2">
+                        {applicationPackage.applicationTips.map((tip, idx) => (
+                          <li key={idx} className="text-sm text-slate-300 flex gap-2">
+                            <span className="text-blue-500 flex-shrink-0">{idx + 1}.</span>
+                            {tip}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  {/* Skill Gap Advice */}
+                  {applicationPackage.skillGapAdvice && (
+                    <div className="bg-yellow-500/5 border border-yellow-500/20 rounded-lg p-4">
+                      <h4 className="text-sm font-semibold text-yellow-400 mb-2 flex items-center gap-2">
+                        <Lightbulb className="w-4 h-4" /> Addressing Skill Gaps
+                      </h4>
+                      <p className="text-sm text-slate-300 leading-relaxed">
+                        {applicationPackage.skillGapAdvice}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Footer actions */}
+          {applicationPackage && (
+            <div className="border-t border-white/10 pt-4 flex items-center justify-between gap-3">
+              <a
+                href={job.applyUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-blue-400 hover:text-blue-300 transition-colors underline underline-offset-2"
+              >
+                View job listing
+              </a>
+              <button
+                onClick={markAsApplied}
+                disabled={isMarkingApplied || isApplied}
+                className={`flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold text-sm transition-all ${
+                  isApplied
+                    ? 'bg-green-600/30 text-green-300 border border-green-500/30 cursor-default'
+                    : 'bg-green-600 hover:bg-green-700 disabled:opacity-60 disabled:cursor-not-allowed'
+                }`}
+              >
+                {isApplied ? (
+                  <><Check className="w-4 h-4" /> Marked as Applied!</>
+                ) : isMarkingApplied ? (
+                  <><RefreshCw className="w-4 h-4 animate-spin" /> Saving...</>
+                ) : (
+                  <><CheckSquare className="w-4 h-4" /> Mark as Applied</>
+                )}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ApplyAIModal;

--- a/frontend/src/components/JobListings.tsx
+++ b/frontend/src/components/JobListings.tsx
@@ -4,6 +4,7 @@ import * as configApi from '../services/configApi';
 import type { JobThresholds } from '../services/configApi';
 import { API_BASE_URL } from '../config';
 import logger from '../services/logger';
+import ApplyAIModal from './ApplyAIModal';
 
 interface CompanyInfo {
   name: string;
@@ -46,6 +47,8 @@ const JobListings: React.FC<JobListingsProps> = ({ jobs }) => {
   const [companyInfo, setCompanyInfo] = useState<Record<string, CompanyInfo>>({});
   const [expandedCompanies, setExpandedCompanies] = useState<Set<string>>(new Set());
   const [loadingCompanies, setLoadingCompanies] = useState<Set<string>>(new Set());
+  const [applyModalJob, setApplyModalJob] = useState<Job | null>(null);
+  const [appliedJobIds, setAppliedJobIds] = useState<Set<string>>(new Set());
   
   // Configurable thresholds
   const [thresholds, setThresholds] = useState<JobThresholds>({
@@ -199,6 +202,7 @@ const JobListings: React.FC<JobListingsProps> = ({ jobs }) => {
   };
 
   return (
+    <>
     <div className="space-y-4">
       <div className="flex items-center justify-between mb-4">
         <div>
@@ -290,6 +294,15 @@ const JobListings: React.FC<JobListingsProps> = ({ jobs }) => {
                 {company?.heatScore && company.heatScore >= 7 && (
                   <span className="bg-orange-500/20 px-2 py-0.5 rounded-full text-xs text-orange-300 flex items-center gap-1">
                     🔥 Hot
+                  </span>
+                )}
+                {(job.source.includes('LinkedIn') || job.source === 'JSearch') &&
+                  getJobFreshness(job.postedAt).daysAgo > 7 && (
+                  <span
+                    className="bg-yellow-500/10 px-2 py-0.5 rounded-full text-xs text-yellow-400 flex items-center gap-1 border border-yellow-500/20"
+                    title="LinkedIn listings expire quickly. Verify before applying."
+                  >
+                    ⚠️ May be expired
                   </span>
                 )}
               </div>
@@ -445,7 +458,7 @@ const JobListings: React.FC<JobListingsProps> = ({ jobs }) => {
             </p>
 
             {/* Actions */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap">
               <a
                 href={job.applyUrl}
                 target="_blank"
@@ -455,6 +468,18 @@ const JobListings: React.FC<JobListingsProps> = ({ jobs }) => {
                 <ExternalLink className="w-4 h-4" />
                 View & Apply
               </a>
+              <button
+                onClick={() => setApplyModalJob(job)}
+                className="flex items-center gap-2 bg-purple-600 hover:bg-purple-700 px-4 py-2 rounded-lg transition-colors text-sm font-semibold"
+              >
+                <Briefcase className="w-4 h-4" />
+                Apply with AI
+              </button>
+              {appliedJobIds.has(job.id) && (
+                <span className="flex items-center gap-1.5 bg-green-500/20 text-green-300 px-3 py-1.5 rounded-lg text-xs font-semibold border border-green-500/30">
+                  ✓ Applied
+                </span>
+              )}
               {(() => {
                 const freshness = getJobFreshness(job.postedAt);
                 return (
@@ -475,6 +500,18 @@ const JobListings: React.FC<JobListingsProps> = ({ jobs }) => {
         );
       })}
     </div>
+
+    {applyModalJob && (
+      <ApplyAIModal
+        job={applyModalJob}
+        onClose={() => setApplyModalJob(null)}
+        onMarkedApplied={(jobId) => {
+          setAppliedJobIds(prev => new Set([...prev, jobId]));
+          setApplyModalJob(null);
+        }}
+      />
+    )}
+    </>
   );
 };
 


### PR DESCRIPTION
… fixes

- Fix JSearch staleness: date_posted changed from 'month' to 'week' to avoid returning expired LinkedIn listings
- Fix Adzuna country-code bug: was returning [] for all non-mapped locations (including US); now only skips Israel (unsupported)
- Add Jobicy API integration: free remote jobs, no auth, tag-based search, wired into searchAllSources() alongside other free APIs
- Add StartupNationCentral service: discovers Israeli startups and surfaces them as career page leads; degrades gracefully on 403
- Add Apply AI feature: Claude Sonnet generates cover letter, email template, application tips, skill gap advice, and key strengths
- Add application tracking: POST /apply-ai, POST /application/track, GET /applications routes + DB fields (coverLetter, emailTemplate, applicationDocs) on SavedJob via prisma db push
- Add ApplyAIModal: tabbed UI with tone selector, editable outputs, copy buttons, and Mark as Applied CTA
- Add LinkedIn staleness badge in JobListings for JSearch/LinkedIn sources older than 7 days